### PR TITLE
Fix ls command to find out latest version installed

### DIFF
--- a/tower-setup/README.adoc
+++ b/tower-setup/README.adoc
@@ -2,7 +2,7 @@
 Eric Lavarde <elavarde@redhat.com>
 v1.1, 2018-10-02
 
-It's a rather simple role to automate the upgrade of a Tower. It changed slightly over time but is known to have worked from 3.0.2 to 3.2.2, and from 3.2.1 to 3.2.5 to 3.3.0.
+It's a rather simple role to automate the upgrade of a Tower. It changed slightly over time but is known to have worked from 3.0.2 to 3.2.2, and from 3.2.1 to 3.2.5 to 3.3.0, and then up to 3.3.4.
 
 The steps to use it are relatively simple:
 

--- a/tower-setup/roles/autocop.tower-setup/tasks/main.yml
+++ b/tower-setup/roles/autocop.tower-setup/tasks/main.yml
@@ -24,7 +24,7 @@
 # --- identify the correct setup directory --- #
 
 - name: list versioned or existing ansible-tower-setup-bundle directories
-  shell: ls -dv {{ tower_working_dir }}/{{ tower_name | regex_replace('latest','*') }}/
+  shell: ls -dv1 {{ tower_working_dir }}/{{ tower_name | regex_replace('latest','*') }}/
   register: tower_dirs
   changed_when: no
 - name: identify the correct tower-setup-bundle directory


### PR DESCRIPTION
Added `-1` to make sure each found Tower directory is on its own line so that the ls output is properly parsed. Not directly related to Tower 3.3 but issue found out during upgrade because I had more than one tower installation directory.