### PR TITLE
Small changes to support Ansible 2.8 and Tower 3.5 support check mode

### DIFF
--- a/tower-setup/README.adoc
+++ b/tower-setup/README.adoc
@@ -1,8 +1,8 @@
 = Playbook to automate upgrade of Tower =
 Eric Lavarde <elavarde@redhat.com>
-v1.1, 2018-10-02
+v1.2, 2019-08-08
 
-It's a rather simple role to automate the upgrade of a Tower. It changed slightly over time but is known to have worked from 3.0.2 to 3.2.2, and from 3.2.1 to 3.2.5 to 3.3.0, and then up to 3.3.4.
+It's a rather simple role to automate the upgrade of a Tower. It changed slightly over time but is known to have worked from 3.0.2 to 3.2.2, and from 3.2.1 to 3.2.5 to 3.3.0, and then up to 3.3.4, 3.4.2 and 3.5.1.
 
 The steps to use it are relatively simple:
 

--- a/tower-setup/roles/autocop.tower-setup/README.md
+++ b/tower-setup/roles/autocop.tower-setup/README.md
@@ -12,7 +12,9 @@ The role should work without any specific variable defined, but you probably wan
 - create a backup prior to upgrading
 - adapt the working directory
 
-The role can today only be used for a single tower installation with embedded database (i.e. no cluster, no external database).
+The role can today only be used for a single tower installation with embedded database (i.e. no cluster, no external database). It is mostly idempotent as long as the setup.sh of Tower installation is (which it is today), even if the preparation steps might show some changed tasks (unpacking the tarball and patching the inventory).
+
+The role works ok in check mode (as long as a setup directory has been unpacked).
 
 Requirements
 ------------

--- a/tower-setup/roles/autocop.tower-setup/tasks/main.yml
+++ b/tower-setup/roles/autocop.tower-setup/tasks/main.yml
@@ -27,6 +27,7 @@
   shell: ls -dv1 {{ tower_working_dir }}/{{ tower_name | regex_replace('latest','*') }}/
   register: tower_dirs
   changed_when: no
+  check_mode: no  # run also in check mode to get list of files in all cases
 - name: identify the correct tower-setup-bundle directory
   set_fact:
     tower_setup_dir: "{{ tower_dirs.stdout_lines[-1] }}"
@@ -53,7 +54,7 @@
     name: "{{ tower_sw_packages }}"
     state: latest
     update_cache: yes
-  when: tower_sw_packages
+  when: tower_sw_packages | bool
 
 # --- optionally backup Tower and run the installation / upgrade --- #
 


### PR DESCRIPTION
Some documentation updates in regard to Tower 3.5
Remove warning from Ansible 2.8 in regard to bare variable as boolean
Make sure listing of setup repos runs also in check mode